### PR TITLE
グループ情報を一括修正できない問題を修正

### DIFF
--- a/src/pages/Group/GroupDetail/Group.tsx
+++ b/src/pages/Group/GroupDetail/Group.tsx
@@ -211,7 +211,7 @@ export function GroupProfileInfo(props: {
                     }}
                     variant="outlined"
                     onChange={(event) => {
-                      setGroup({ ...data, postcode: event.target.value })
+                      setGroup(prev => ({ ...prev, postcode: event.target.value }))
                     }}
                   />
                   <StyledTextFieldMedium
@@ -224,7 +224,7 @@ export function GroupProfileInfo(props: {
                     }}
                     variant="outlined"
                     onChange={(event) => {
-                      setGroup({ ...data, address: event.target.value })
+                      setGroup(prev => ({ ...prev, address: event.target.value }))
                     }}
                   />
                   <StyledTextFieldMedium
@@ -237,7 +237,7 @@ export function GroupProfileInfo(props: {
                     }}
                     variant="outlined"
                     onChange={(event) => {
-                      setGroup({ ...data, address_en: event.target.value })
+                      setGroup(prev => ({ ...prev, address_en: event.target.value }))
                     }}
                   />
                   <StyledTextFieldVeryShort1
@@ -250,7 +250,7 @@ export function GroupProfileInfo(props: {
                     }}
                     variant="outlined"
                     onChange={(event) => {
-                      setGroup({ ...data, tel: event.target.value })
+                      setGroup(prev => ({ ...prev, tel: event.target.value }))
                     }}
                   />
                   <StyledTextFieldVeryShort1
@@ -263,7 +263,7 @@ export function GroupProfileInfo(props: {
                     }}
                     variant="outlined"
                     onChange={(event) => {
-                      setGroup({ ...data, country: event.target.value })
+                      setGroup(prev => ({ ...prev, country: event.target.value }))
                     }}
                   />
                 </StyledRootForm>


### PR DESCRIPTION
## 現状
- 複数のフィールドを編集しても、最後に編集したフィールドしか保存されない
<img width="452" height="394" alt="image" src="https://github.com/user-attachments/assets/c1354126-8daf-4b2f-b938-42a6cb8b8b1d" />

## 修正点
- 複数のフィールドを編集しても編集したフィールドすべてが保存されるように修正
<img width="466" height="244" alt="image" src="https://github.com/user-attachments/assets/561074e4-d727-4125-8e23-64274fe65846" />
